### PR TITLE
A little cleanup to incorporate into the viewfield D8 module.

### DIFF
--- a/src/Plugin/Field/FieldFormatter/ViewfieldDefaultFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/ViewfieldDefaultFormatter.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\viewfield\Plugin\Field\FieldFormatter\ViewfieldDefaultFormatter.
- */
-
-
 namespace Drupal\viewfield\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FormatterBase;
@@ -50,4 +44,5 @@ class ViewfieldDefaultFormatter extends FormatterBase {
     }
     return $elements;
   }
+
 }

--- a/src/Plugin/Field/FieldType/ViewfieldItem.php
+++ b/src/Plugin/Field/FieldType/ViewfieldItem.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\viewfield\Plugin\Field\FieldType\ViewfieldItem.
- */
-
 namespace Drupal\viewfield\Plugin\Field\FieldType;
 
 use Drupal\Core\TypedData\DataDefinition;
@@ -12,7 +7,6 @@ use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Field\FieldItemBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\Views;
-
 
 /**
  * Plugin implementation of the 'viewfield' field type.
@@ -27,7 +21,7 @@ use Drupal\views\Views;
  */
 class ViewfieldItem extends FieldItemBase {
 
-  static $propertyDefinitions;
+  public static $propertyDefinitions;
 
   /**
    * {@inheritdoc}
@@ -36,7 +30,6 @@ class ViewfieldItem extends FieldItemBase {
     $value = $this->get('vname')->getValue();
     return empty($value);
   }
-
 
   /**
    * {@inheritdoc}
@@ -48,7 +41,6 @@ class ViewfieldItem extends FieldItemBase {
     ) + parent::defaultFieldSettings();
   }
 
-
   /**
    * {@inheritdoc}
    */
@@ -58,14 +50,16 @@ class ViewfieldItem extends FieldItemBase {
         'vname' => array(
           'type' => 'varchar',
           'not null' => FALSE,
-          // Views requires at least 96 chars for the view name and display, plus
-          // we need 1 for our delimiter. Round up to a common value of 128.
+          // Views requires at least 96 chars for the view name and display,
+          // plus we need 1 for our delimiter. Round up to a common value of
+          // 128.
           'length' => 128,
         ),
         'vargs' => array(
           'type' => 'varchar',
           'not null' => FALSE,
-          'length' => 255, //viewfield_field_instance_settings_form_validate
+          // Note: viewfield_field_instance_settings_form_validate.
+          'length' => 255,
         ),
       ),
     );
@@ -82,9 +76,9 @@ class ViewfieldItem extends FieldItemBase {
     return $properties;
   }
 
- /**
-  * {@inheritdoc}
-  */
+  /**
+   * {@inheritdoc}
+   */
   public function fieldSettingsForm(array $form, FormStateInterface $form_state) {
     $form = array(
       '#element_validate' => array(array(get_class($this), 'fieldSettingsFormValidate')),
@@ -115,11 +109,14 @@ class ViewfieldItem extends FieldItemBase {
   public static function fieldSettingsFormValidate(array $form, FormStateInterface $form_state) {
     $force_default = $form_state->getValue(array('settings', 'force_default'));
     if ($force_default) {
-      /**
-       * @var \Drupal\Core\Field\FieldConfigBase
-       */
+      // The $field is of type \Drupal\Core\Field\FieldConfigBase.
       $field = $form_state->getFormObject()->getEntity();
-      $default_value_vname = $form_state->getValue(array('default_value_input', $field->getName(), 0, 'vname'));
+      $default_value_vname = $form_state->getValue(array(
+        'default_value_input',
+        $field->getName(),
+        0,
+        'vname',
+      ));
       if (empty($default_value_vname)) {
         $form_state->setErrorByName('default_value_input', t('%title requires a default value.', array(
           '%title' => $form['force_default']['#title'],
@@ -127,4 +124,5 @@ class ViewfieldItem extends FieldItemBase {
       }
     }
   }
+
 }

--- a/src/Plugin/Field/FieldWidget/ViewfieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/ViewfieldWidget.php
@@ -1,16 +1,10 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\viewfield\Plugin\Field\FieldWidget\ViewfieldWidget.
- */
-
 namespace Drupal\viewfield\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element;
 use Drupal\views\Views;
 
 /**
@@ -25,7 +19,6 @@ use Drupal\views\Views;
  * )
  */
 class ViewfieldWidget extends WidgetBase {
-
 
   /**
    * {@inheritdoc}
@@ -48,17 +41,17 @@ class ViewfieldWidget extends WidgetBase {
       '#title' => t('Arguments'),
       '#default_value' => isset($items[$delta]->vargs) ? $items[$delta]->vargs : NULL,
       '#access' => !$field_settings['force_default'],
-      '#description' => t('A comma separated list of arguments to pass to the selected view. '),
+      '#description' => t('A comma separated list of arguments to pass to the selected view.'),
     );
 
     return $element;
   }
 
   /**
-   * Returns a select options list of views displays of enabled and allowed views.
+   * Returns a select options list of enabled and allowed views displays.
    *
-   * @param array @settings
-   *   The field settings
+   * @param array $settings
+   *   The field settings.
    *
    * @return array
    *   An array with the allowed and enabled views and displays.
@@ -68,8 +61,8 @@ class ViewfieldWidget extends WidgetBase {
     $views = Views::getEnabledViews();
     // Limit to allowed values, if any.
     if (isset($settings['allowed_views']) && is_array($settings['allowed_views'])) {
-      // Only intersect if at least one view has been enabled; otherwise, we would
-      // end up with empty $views.
+      // Only intersect if at least one view has been enabled; otherwise, we
+      // would end up with empty $views.
       if ($allowed = array_filter($settings['allowed_views'])) {
         $views = array_intersect_key($views, $allowed);
       }

--- a/src/Tests/ViewFieldTest.php
+++ b/src/Tests/ViewFieldTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains Drupal\viewfield\Tests\ViewFieldTest.
- */
-
 namespace Drupal\viewfield\Tests;
 
 use Drupal\Component\Utility\Unicode;
@@ -38,6 +33,9 @@ class ViewFieldTest extends WebTestBase {
    */
   protected $field;
 
+  /**
+   * Set up the test.
+   */
   protected function setUp() {
     parent::setUp();
 
@@ -52,7 +50,7 @@ class ViewFieldTest extends WebTestBase {
   /**
    * Test field creation and attachment to an article.
    */
-  function testFieldCreation() {
+  public function testFieldCreation() {
     $field_name = Unicode::strtolower($this->randomMachineName());
     // Create a field with settings to validate.
     $this->fieldStorage = entity_create('field_storage_config', array(
@@ -87,19 +85,25 @@ class ViewFieldTest extends WebTestBase {
     $this->assertViewDisplays($field_name);
   }
 
+  /**
+   * Assert that the node was created.
+   *
+   * @param string $field_name
+   *   A name of the field.
+   */
   protected function assertNodeCreated($field_name) {
     // Display article creation form.
     $this->drupalGet('node/add/article');
     $view_select_name = "{$field_name}[0][vname]";
-    $this->assertFieldByName($view_select_name, NULL,'Views select list is displayed.');
-    $this->assertFieldByName("{$field_name}[0][vargs]", '' ,
+    $this->assertFieldByName($view_select_name, NULL, 'Views select list is displayed.');
+    $this->assertFieldByName("{$field_name}[0][vargs]", '',
       'Views arguments text field is displayed');
 
-    $edit = array (
+    $edit = array(
       "title[0][value]" => 'Test',
       $view_select_name => 'user_admin_people|default',
     );
-    // create article with viewfield
+    // Create article with viewfield.
     $this->drupalPostForm(NULL, $edit, t('Save and publish'));
     $this->assertText(t('Article Test has been created.'));
   }
@@ -108,37 +112,40 @@ class ViewFieldTest extends WebTestBase {
    * Assert that the view is displayed on a node.
    *
    * @param string $field_name
-   *   The field to test
+   *   The field to test.
    */
   protected function assertViewDisplays($field_name) {
-    // create article
+    // Create article.
     $this->drupalGet('node/add/article');
     $view_select_name = "{$field_name}[0][vname]";
-    $edit = array (
+    $edit = array(
       "title[0][value]" => 'Test1',
       $view_select_name => 'user_admin_people|default',
     );
     $this->drupalPostForm(NULL, $edit, t('Save and publish'));
-    
-    // test that the view displays on the node
+
+    // Test that the view displays on the node.
     $elements = $this->xpath("//div[contains(@class,:class) and contains(@class,:class1)]",
-      array(':class' => 'view-user-admin-people',':class1' => 'view-display-id-default'));
+      array(':class' => 'view-user-admin-people', ':class1' => 'view-display-id-default'));
     $this->assertTrue(!empty($elements), 'Node contains the correct view and display.');
-    $elements = $this->xpath("//a[@href=:href]",array(':href' => '/user/1'));
+    $elements = $this->xpath("//a[@href=:href]", array(':href' => '/user/1'));
     $this->assertTrue(!empty($elements), 'View is displaying the content.');
   }
 
   /**
-   * Assert that a default view is required when default value checkbox is checked.
+   * Assert for a default view  when default value checkbox is checked.
+   *
+   * Assert that a default view is required when default value checkbox is
+   * checked.
    *
    * @param string $field_name
-   *   The field to test
+   *   The field to test.
    */
   protected function assertDefaultViewRequired($field_name) {
     $this->drupalGet("admin/structure/types/manage/article/fields/node.article.{$field_name}");
     $default_chk_name = 'field[settings][force_default]';
-    $this->assertFieldByName($default_chk_name, NULL,'Default value checkbox displayed');
-    $edit = array (
+    $this->assertFieldByName($default_chk_name, NULL, 'Default value checkbox displayed');
+    $edit = array(
       $default_chk_name => TRUE,
     );
     $this->drupalPostForm(NULL, $edit, t('Save settings'));
@@ -149,30 +156,30 @@ class ViewFieldTest extends WebTestBase {
    * Assert that the default view is selected on the node add form.
    *
    * @param string $field_name
-   *   The field to test
+   *   The field to test.
    */
   protected function assertDefaultViewSelected($field_name) {
     $this->drupalGet("admin/structure/types/manage/article/fields/node.article.{$field_name}");
     $default_view_select_name = "default_value_input[{$field_name}][0][vname]";
-    $this->assertFieldByName($default_view_select_name, NULL,'Default view select list is displayed');
-    $edit = array (
+    $this->assertFieldByName($default_view_select_name, NULL, 'Default view select list is displayed');
+    $edit = array(
       $default_view_select_name => 'user_admin_people|default',
     );
     $this->drupalPostForm(NULL, $edit, t('Save settings'));
     $this->assertText("Saved {$field_name} configuration");
 
-    // check that the view is preselected on the node form
+    // Check that the view is preselected on the node form.
     $this->drupalGet('node/add/article');
     $view_select_name = "{$field_name}[0][vname]";
 
-    $this->assertFieldByName($view_select_name, 'user_admin_people|default','Views select list is displayed with correct value');
+    $this->assertFieldByName($view_select_name, 'user_admin_people|default', 'Views select list is displayed with correct value');
 
-    // return the default value to its original state
+    // Return the default value to its original state.
     $this->drupalGet("admin/structure/types/manage/article/fields/node.article.{$field_name}");
-    $edit = array (
+    $edit = array(
       $default_view_select_name => '0',
     );
     $this->drupalPostForm(NULL, $edit, t('Save settings'));
-
   }
+
 }

--- a/viewfield.module
+++ b/viewfield.module
@@ -24,7 +24,15 @@ function viewfield_theme() {
  */
 function viewfield_preprocess_viewfield_formatter_default(&$variables) {
   $element = $variables['element'];
-  $view_el = $element['#view']->preview($element['#view_display'], array($element['#view_arguments']));
+
+  if (!empty($element['#view_arguments'])) {
+    // Use direct user input from Arguments field.
+    $view_el = $element['#view']->preview($element['#view_display'], array($element['#view_arguments']));
+  }
+  else {
+    // Allow to use contextual filters set in view.
+    $view_el = $element['#view']->preview($element['#view_display']);
+  }
   $output = render ($view_el);
   $variables['output'] = $output;
 }

--- a/viewfield.module
+++ b/viewfield.module
@@ -1,12 +1,11 @@
 <?php
 
-use \Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
-
 /**
  * @file
  * Defines a field type to display a view.
  */
+
+use Drupal\Core\Url;
 
 /**
  * Implements hook_theme().
@@ -33,7 +32,7 @@ function viewfield_preprocess_viewfield_formatter_default(&$variables) {
     // Allow to use contextual filters set in view.
     $view_el = $element['#view']->preview($element['#view_display']);
   }
-  $output = render ($view_el);
+  $output = render($view_el);
   $variables['output'] = $output;
 }
 
@@ -50,7 +49,7 @@ function viewfield_element_info() {
 }
 
 /**
- * #pre_render callback for a viewfield field.
+ * Used as a #pre_render callback for a viewfield field.
  *
  * @see viewfield_post_render()
  */
@@ -83,7 +82,7 @@ function viewfield_pre_render($element) {
 }
 
 /**
- * #post_render callback for a viewfield field.
+ * Used as a #post_render callback for a viewfield field.
  *
  * @see viewfield_pre_render()
  */
@@ -93,9 +92,8 @@ function viewfield_post_render($content, $element) {
   return $content;
 }
 
-
 /**
- * Perform argument replacement
+ * Perform argument replacement.
  */
 function _viewfield_get_view_args($vargs, $entity_type, $entity) {
   $args = array();
@@ -120,7 +118,7 @@ function _viewfield_get_view_args($vargs, $entity_type, $entity) {
       elseif (($comma = strpos($vargs, ',', $pos)) !== FALSE) {
         // Otherwise, get everything before next comma.
         $args[] = substr($vargs, $pos, $comma - $pos);
-        // Skip to after comma and repeat
+        // Skip to after comma and repeat.
         $pos = $comma + 1;
         $found = TRUE;
       }


### PR DESCRIPTION
1.) Applied patch viewfield-allow_contextual_filters.patch from Drupal.org issue: https://www.drupal.org/node/2220929
2.) Done cleanup (fixes) in code to pass PHP Code Sniffer (necessary for some development tools workflow that allow build only when no errors found, including phpcs check).
