### PR TITLE
Add optgroups and labels to View selection widget

### DIFF
--- a/src/Plugin/Field/FieldWidget/ViewfieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/ViewfieldWidget.php
@@ -78,7 +78,7 @@ class ViewfieldWidget extends WidgetBase {
     foreach ($views as $view_name => $view) {
       $displays = $view->get('display');
       foreach ($displays as $display) {
-        $options[$view->id() . '|' . $display['id']] = $view->id() . ' - ' . $display['display_title'];
+        $options[$view->label()][$view->id() . '|' . $display['id']] = $view->label() . ' - ' . $display['display_title'];
       }
     }
     return $options;


### PR DESCRIPTION
Optgroups and the use of "human-readable" names will make this field less intimidating for non or semi-technical users